### PR TITLE
automatic locale syncing for English variants AU/CA/IN/GB

### DIFF
--- a/jellyfin_alexa_skill/alexa/setup/manifest/manifest.json
+++ b/jellyfin_alexa_skill/alexa/setup/manifest/manifest.json
@@ -43,6 +43,12 @@
           "description": "Spiele Medien von deinem Jellyfin Server.\n\nQuellcode: https://github.com/infinityofspace/jellyfin_alexa_skill"
         }
       },
+      "automaticClonedLocale": {
+        "locales":[ {
+          "source": "en-US",
+          "targets": ["en-AU", "en-CA", "en-IN", "en-GB"]
+        } ]
+      },
       "testingInstructions": ""
     }
   }


### PR DESCRIPTION
Synchronises and clones primary locale (en-US) with secondary locales en-AU, en-CA, en-IN and en-GB.  This assumes that the Jellyfin Alexa skill will have a consistent interaction model across all English language variants.

This is a simple change that allows the skill to be used natively in other English speaking regions.

The code is taken straight from the FAQ section in [Add additional locales of the same language to custom skills](https://www.developer.amazon.com/en-US/docs/alexa/custom-skills/add-additional-locales-of-the-same-language-to-your-custom-skills.html).  I just reformatted the example json to be consistent with the rest of the file.

This works on my Alexa device, which uses en-AU.  You can see the additional languages on the Alexa developer console.  After you rebuild, the locale sync should be automatic.