### PR TITLE
override invocation name in skill.conf

### DIFF
--- a/jellyfin_alexa_skill/alexa/setup/manifest/manifest.py
+++ b/jellyfin_alexa_skill/alexa/setup/manifest/manifest.py
@@ -17,3 +17,17 @@ def get_skill_version(manifest: SkillManifestEnvelope) -> str:
         name = ""
     skill_version = name.replace(BASE_NAME + "_", "")
     return skill_version
+
+
+# update SKILL_MANIFEST's display name and example phrases with "new_name" for the "locale" language
+def update_display_name(locale:str, new_name:str):
+    default_name = SKILL_MANIFEST.manifest.publishing_information.locales[locale].name
+
+    SKILL_MANIFEST.manifest.publishing_information.locales[locale].name = new_name
+
+    idx = 0
+    for phrase in SKILL_MANIFEST.manifest.publishing_information.locales[locale].example_phrases:
+        SKILL_MANIFEST.manifest.publishing_information.locales[locale].example_phrases[idx] = phrase.replace(default_name,new_name)
+        idx += 1
+
+    return

--- a/jellyfin_alexa_skill/main.py
+++ b/jellyfin_alexa_skill/main.py
@@ -21,7 +21,8 @@ from pyngrok import conf, ngrok
 from jellyfin_alexa_skill import __version__
 from jellyfin_alexa_skill.alexa.handler import get_skill_builder
 from jellyfin_alexa_skill.alexa.setup.interaction.model import INTERACTION_MODEL_DE_DE, INTERACTION_MODEL_EN_US
-from jellyfin_alexa_skill.alexa.setup.manifest.manifest import get_skill_version, SKILL_MANIFEST
+from jellyfin_alexa_skill.alexa.setup.manifest.manifest import get_skill_version, SKILL_MANIFEST, update_display_name
+
 from jellyfin_alexa_skill.alexa.web.skill import get_skill_blueprint
 from jellyfin_alexa_skill.config import get_config, DEFAULT_ALEXA_SKILL_CONFIG_PATH, DEFAULT_ALEXA_SKILL_DATA_PATH, \
     APP_NAME
@@ -150,20 +151,34 @@ def main():
 
     skill_version = get_skill_version(manifest)
 
+    # check if the invocation name has an override in skill.config, or if name has otherwise changed
+    model_changed = False
+
+    if ("en-US" in config) and ("invocation_name" in config["en-US"]):
+        invocation_name = config["en-US"]["invocation_name"].lower()
+        INTERACTION_MODEL_EN_US.interaction_model.language_model.invocation_name = invocation_name
+
+    current_model = smapi_client.get_interaction_model_v1(skill_id=skill_id, stage_v2=stage, locale="en_US")
+    current_name = current_model.interaction_model.language_model.invocation_name
+    if current_name != INTERACTION_MODEL_EN_US.interaction_model.language_model.invocation_name:
+        logging.info("[en-US] invocation name changed to [%s]",
+                       INTERACTION_MODEL_EN_US.interaction_model.language_model.invocation_name)
+        model_changed = True
+
+    if ("de-DE" in config) and ("invocation_name" in config["de-DE"]):
+        invocation_name = config["de-DE"]["invocation_name"].lower()
+        INTERACTION_MODEL_DE_DE.interaction_model.language_model.invocation_name = invocation_name
+
+    current_model = smapi_client.get_interaction_model_v1(skill_id=skill_id, stage_v2=stage, locale="de_DE")
+    current_name = current_model.interaction_model.language_model.invocation_name
+    if current_name != INTERACTION_MODEL_DE_DE.interaction_model.language_model.invocation_name:
+        logging.info("[de-DE] invocation name changed to [%s]",
+                       INTERACTION_MODEL_DE_DE.interaction_model.language_model.invocation_name)
+        model_changed = True
+
     # update the skill in the could when we are on an older version or force reset to clean manual changes
-    if config["general"].getboolean("force_reset_skill") or skill_version != __version__:
+    if config["general"].getboolean("force_reset_skill") or skill_version != __version__ or model_changed:
         logging.info("Updating skill interaction model...")
-
-        # check if there is an override of interaction model in skill.config
-        if ("en-US" in config) and ("invocation_name" in config["en-US"]):
-            invocation_name = config["en-US"]["invocation_name"]
-            logging.info("OVERRIDE [en-US]: invocation_name [%s]", invocation_name)
-            INTERACTION_MODEL_EN_US.interaction_model.language_model.invocation_name = invocation_name
-
-        if ("de-DE" in config) and ("invocation_name" in config["de-DE"]):
-            invocation_name = config["de-DE"]["invocation_name"]
-            logging.info("OVERRIDE [de-DE]: invocation_name [%s]", invocation_name)
-            INTERACTION_MODEL_DE_DE.interaction_model.language_model.invocation_name = invocation_name
 
         smapi_client.set_interaction_model_v1(skill_id=skill_id,
                                               stage_v2=stage,
@@ -192,37 +207,40 @@ def main():
     else:
         raise Exception("Invalid ssl certificate type defined")
 
+    # check if there is an override of display name in skill.config, or a change otherwise
+    change_manifest = False
+
+    display_name = SKILL_MANIFEST.manifest.publishing_information.locales["en-US"].name
+    if ("en-US" in config) and ("display_name" in config["en-US"]):
+        display_name = config["en-US"]["display_name"]
+        update_display_name(locale="en-US",new_name=display_name)
+
+    current_name = manifest.manifest.publishing_information.locales["en-US"].name
+    if (current_name != display_name):
+        change_manifest = True
+
+    display_name = SKILL_MANIFEST.manifest.publishing_information.locales["de-DE"].name
+    if ("de-DE" in config) and ("display_name" in config["de-DE"]):
+        display_name = config["de-DE"]["display_name"]
+        update_display_name(locale="de-DE",new_name=display_name)
+
+    current_name = manifest.manifest.publishing_information.locales["de-DE"].name
+    if (current_name != display_name):
+        change_manifest = True
+
     # check if the current saved endpoint or ssl cert type requires an update
     if config["general"].getboolean("force_reset_skill") \
             or skill_version != __version__ \
             or manifest.manifest.apis.custom.endpoint is None \
             or manifest.manifest.apis.custom.endpoint.uri != skill_endpoint \
-            or manifest.manifest.apis.custom.endpoint.ssl_certificate_type != ssl_cert_type:
+            or manifest.manifest.apis.custom.endpoint.ssl_certificate_type != ssl_cert_type \
+            or change_manifest:
         logging.info("Updating skill endpoint...")
 
         manifest = SKILL_MANIFEST
 
         manifest.manifest.apis.custom.endpoint = SkillManifestEndpoint(skill_endpoint,
                                                                        ssl_certificate_type=ssl_cert_type)
-
-        # check if there is an override of manifest name in skill.config
-        if ("en-US" in config) and ("display_name" in config["en-US"]):
-            display_name = config["en-US"]["display_name"]
-            logging.info("OVERRIDE [en-US]: display_name [%s]", display_name)
-
-            # replace "Jellyfin Player" with "display_name" in all 3 example phrases
-            for i in range(3):
-                manifest.manifest.publishing_information.locales["en-US"].example_phrases[i] = \
-                  manifest.manifest.publishing_information.locales["en-US"].example_phrases[i].replace("Jellyfin Player",display_name)
-
-        if ("de-DE" in config) and ("display_name" in config["de-DE"]):
-            display_name = config["de-DE"]["display_name"]
-            logging.info("OVERRIDE [de-DE]: display_name [%s]", display_name)
-
-            # replace "Jellyfin Player" with "display_name" in all 3 example phrases
-            for i in range(3):
-                manifest.manifest.publishing_information.locales["de-DE"].example_phrases[i] = \
-                  manifest.manifest.publishing_information.locales["de-DE"].example_phrases[i].replace("Jellyfin Player",display_name)
 
         smapi_client.update_skill_manifest_v1(skill_id=skill_id,
                                               stage_v2=stage,

--- a/jellyfin_alexa_skill/main.py
+++ b/jellyfin_alexa_skill/main.py
@@ -154,6 +154,17 @@ def main():
     if config["general"].getboolean("force_reset_skill") or skill_version != __version__:
         logging.info("Updating skill interaction model...")
 
+        # check if there is an override of interaction model in skill.config
+        if ("en-US" in config) and ("invocation_name" in config["en-US"]):
+            invocation_name = config["en-US"]["invocation_name"]
+            logging.info("OVERRIDE [en-US]: invocation_name [%s]", invocation_name)
+            INTERACTION_MODEL_EN_US.interaction_model.language_model.invocation_name = invocation_name
+
+        if ("de-DE" in config) and ("invocation_name" in config["de-DE"]):
+            invocation_name = config["de-DE"]["invocation_name"]
+            logging.info("OVERRIDE [de-DE]: invocation_name [%s]", invocation_name)
+            INTERACTION_MODEL_DE_DE.interaction_model.language_model.invocation_name = invocation_name
+
         smapi_client.set_interaction_model_v1(skill_id=skill_id,
                                               stage_v2=stage,
                                               locale="en_US",
@@ -193,6 +204,25 @@ def main():
 
         manifest.manifest.apis.custom.endpoint = SkillManifestEndpoint(skill_endpoint,
                                                                        ssl_certificate_type=ssl_cert_type)
+
+        # check if there is an override of manifest name in skill.config
+        if ("en-US" in config) and ("display_name" in config["en-US"]):
+            display_name = config["en-US"]["display_name"]
+            logging.info("OVERRIDE [en-US]: display_name [%s]", display_name)
+
+            # replace "Jellyfin Player" with "display_name" in all 3 example phrases
+            for i in range(3):
+                manifest.manifest.publishing_information.locales["en-US"].example_phrases[i] = \
+                  manifest.manifest.publishing_information.locales["en-US"].example_phrases[i].replace("Jellyfin Player",display_name)
+
+        if ("de-DE" in config) and ("display_name" in config["de-DE"]):
+            display_name = config["de-DE"]["display_name"]
+            logging.info("OVERRIDE [de-DE]: display_name [%s]", display_name)
+
+            # replace "Jellyfin Player" with "display_name" in all 3 example phrases
+            for i in range(3):
+                manifest.manifest.publishing_information.locales["de-DE"].example_phrases[i] = \
+                  manifest.manifest.publishing_information.locales["de-DE"].example_phrases[i].replace("Jellyfin Player",display_name)
 
         smapi_client.update_skill_manifest_v1(skill_id=skill_id,
                                               stage_v2=stage,

--- a/skill.conf
+++ b/skill.conf
@@ -40,3 +40,17 @@ refresh_token =
 alexa_account_linking_client_id =
 # The flask secret. This value is set automatically
 flask_secret =
+
+#[en-US]
+# override Alexa invocation name for English locales
+# all lower-case: invocation name to use (default: jellyfin player)
+#invocation_name = jelly fin
+# description of invocation name to be used in visual feedback to user (default: Jellyfin Player)
+#display_name = Jellyfin
+
+#[de-DE]
+# override Alexa invocation name for German locale
+# all lower-case: invocation name to use (default: jellyfin player)
+#invocation_name = mein server
+# description of invocation name to be used in visual feedback to user (default: Jellyfin Player)
+#display_name = Mein Server


### PR DESCRIPTION
This relates to issue #8 .

These changes allow user to override "Jellyfin Player" as invocation name in the interaction model.  It also allows user to replace the phrase "Jellyfin Player" in the manifest example phrases.

In the skills.conf there are two sections: [en-US] and [de-DE].  Two keys are allowed: _invocation_name_ and _display_name_.  The _invocation_name_ will override the default invocation name for that locale ("Jellyfin Player").  The _display_name_ will replace the phrase "Jellyfin Player" in the three example phrases for that locale.

The changes to main.py are suggestions.  I have tested the changes I've made and they work.  I am not a python programmer, so there may be more elegant ways to implement the code.  Feel free to suggest improvements.