### PR TITLE
add PlayChannel intent for internet radio streaming (audio only)

### DIFF
--- a/jellyfin_alexa_skill/alexa/handler/__init__.py
+++ b/jellyfin_alexa_skill/alexa/handler/__init__.py
@@ -22,6 +22,7 @@ def get_skill_builder(jellyfin_client: JellyfinClient):
     skill_builder.add_request_handler(SessionEndedRequestHandler())
 
     skill_builder.add_request_handler(PlaySongIntentHandler(jellyfin_client))
+    skill_builder.add_request_handler(PlayChannelIntentHandler(jellyfin_client))
     skill_builder.add_request_handler(PlayVideoIntentHandler(jellyfin_client))
     skill_builder.add_request_handler(PlayArtistSongsIntentHandler(jellyfin_client))
 

--- a/jellyfin_alexa_skill/alexa/setup/interaction/interaction_model_de_DE.json
+++ b/jellyfin_alexa_skill/alexa/setup/interaction/interaction_model_de_DE.json
@@ -61,6 +61,19 @@
           ]
         },
         {
+          "name": "PlayChannelIntent",
+          "samples": [
+            "Spiele den Kanal {channel}",
+            "Spiele den Radio {channel}"
+          ],
+          "slots": [
+            {
+              "name": "channel",
+              "type": "AMAZON.SearchQuery"
+            }
+          ]
+        },
+        {
           "name": "PlaySongIntent",
           "samples": [
             "Spiele den Song {song}",

--- a/jellyfin_alexa_skill/alexa/setup/interaction/interaction_model_en_US.json
+++ b/jellyfin_alexa_skill/alexa/setup/interaction/interaction_model_en_US.json
@@ -61,6 +61,19 @@
           ]
         },
         {
+          "name": "PlayChannelIntent",
+          "samples": [
+            "Play channel {channel}",
+            "Play radio {channel}"
+          ],
+          "slots": [
+            {
+              "name": "channel",
+              "type": "AMAZON.SearchQuery"
+            }
+          ]
+        },
+        {
           "name": "PlaySongIntent",
           "samples": [
             "Play the song {song}",

--- a/jellyfin_alexa_skill/jellyfin/api/client.py
+++ b/jellyfin_alexa_skill/jellyfin/api/client.py
@@ -13,6 +13,7 @@ from jellyfin_alexa_skill.config import APP_NAME
 class MediaType(Enum):
     AUDIO = "Audio"
     VIDEO = "Video"
+    CHANNEL = "TvChannel"
 
 
 class JellyfinClient:


### PR DESCRIPTION
This commit adds the ability to ask Alexa to play an internet radio stream.  It does this by adding a PlayChannel intent to "play radio {channel}" or "play channel {channel}".

Jellyfin has a function to play [internet radio](https://jellyfin.org/docs/general/server/media/internet-radio.html).  The radio station is stored as a LiveTV channel.

The PlayChannelIntent streams the _audio-only_ LiveTv channel from the Jellyfin server.

A future enhancement could add the ability to playback video+audio for LiveTV internet TV channels.

The wiki needs to be updated too:
  * play internet radio station:
      * English: `Play radio <radio-station-name>`, `Play channel <radio-station-name>`
      * German:  `Spiele den Radio <radio-station-name>`, `Spiele den Kanal <radio-station-name>`
      
My German will need to be checked.  High school was a _long_ time ago.