### PR TITLE
stream Jellyfin LiveTV video channels

### DIFF
--- a/jellyfin_alexa_skill/alexa/handler/channel.py
+++ b/jellyfin_alexa_skill/alexa/handler/channel.py
@@ -5,7 +5,8 @@ from ask_sdk_core.utils import is_intent_name
 from ask_sdk_model import Response
 
 from jellyfin_alexa_skill.alexa.handler.base import BaseHandler
-from jellyfin_alexa_skill.alexa.util import build_stream_response, MediaTypeSlot, translate, get_similarity, best_matches_by_idx
+from jellyfin_alexa_skill.alexa.util import build_stream_response, MediaTypeSlot, translate, get_similarity, \
+    best_matches_by_idx, ReturnCode
 from jellyfin_alexa_skill.database.db import set_playback_queue
 from jellyfin_alexa_skill.database.model.playback import PlaybackItem
 from jellyfin_alexa_skill.database.model.user import User
@@ -54,12 +55,17 @@ class PlayChannelIntentHandler(BaseHandler):
             user_id = handler_input.request_envelope.context.system.user.user_id
             playback = set_playback_queue(user_id, [PlaybackItem(item["Id"], item["Name"], [])])
 
-            build_stream_response(jellyfin_client=self.jellyfin_client,
-                                  jellyfin_user_id=user.jellyfin_user_id,
-                                  jellyfin_token=user.jellyfin_token,
-                                  handler_input=handler_input,
-                                  playback=playback,
-                                  idx=0)
+            rc = build_stream_response(jellyfin_client=self.jellyfin_client,
+                                       jellyfin_user_id=user.jellyfin_user_id,
+                                       jellyfin_token=user.jellyfin_token,
+                                       handler_input=handler_input,
+                                       playback=playback,
+                                       idx=0)
+
+            if rc == ReturnCode.ERROR_NOT_VIDEO_DEVICE:
+                # device does not support video
+                response_text = translation.gettext("I'm sorry, I can't play videos on this device.")
+                handler_input.response_builder.speak(response_text)
 
             return handler_input.response_builder.response
 

--- a/jellyfin_alexa_skill/jellyfin/api/client.py
+++ b/jellyfin_alexa_skill/jellyfin/api/client.py
@@ -116,7 +116,10 @@ class JellyfinClient:
         if play_info["MediaSources"][0]:
             for stream in play_info["MediaSources"][0]["MediaStreams"]:
                 if stream["Type"] == "Video":
-                    stream_type = "video"
+                    if play_info["MediaSources"][0]["IsInfiniteStream"] == True:
+                        stream_type = "livetv"
+                    else:
+                        stream_type = "video"
                     break
 
         url = self.server_endpoint

--- a/jellyfin_alexa_skill/jellyfin/api/client.py
+++ b/jellyfin_alexa_skill/jellyfin/api/client.py
@@ -88,6 +88,7 @@ class JellyfinClient:
         Returns [stream_type,url]
                 if stream_type="audio", url is a stream url ready for AudioPlayer
                 if stream_type="video", url is a url to video to pass on to VideoApp
+                if stream_type="livetv", url is a url to stream LiveTV to VideoApp
                 if stream_type="", something went wrong
         """
 
@@ -136,11 +137,13 @@ class JellyfinClient:
             path = f"/Videos/{item_id}/stream"
             params = {
                 "Container" : play_info["MediaSources"][0]["Container"],
-                "Tag": play_info["MediaSources"][0]["ETag"],
                 "PlaySessionId": play_info["PlaySessionId"],
                 'DeviceId': device_id,
                 "api_key": token
             }
+        elif stream_type == "livetv":
+            # just return the direct internet path to the live tv channel (we don't need to use Jellyfin)
+            return stream_type, play_info["MediaSources"][0]["Path"]
 
         params.update(kwargs)
 


### PR DESCRIPTION
Allows streaming of Jellyfin LiveTV video channels.  

To begin a LiveTV stream: `Alexa ask Jellyfin Player to play channel <channel>`

Relates to enhancement #14.