### PR TITLE
add health check for Docker container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,8 @@ services:
     environment:
       - JELLYFIN_ALEXA_SKILL_CONFIG=/skill/config/skill.conf
       - JELLYFIN_ALEXA_SKILL_DATA=/skill/data
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "--tries=1", "http://localhost:1456/healthy"]
 
 volumes:
   jellyfin_config:

--- a/jellyfin_alexa_skill/alexa/web/skill.py
+++ b/jellyfin_alexa_skill/alexa/web/skill.py
@@ -9,4 +9,17 @@ def get_skill_blueprint(skill_adapter: SkillAdapter):
     def invoke_skill():
         return skill_adapter.dispatch_request()
 
+    @skill_blueprint.route("/healthy", methods=["GET"])
+    def health_check():
+        """
+        The docker-compose HEALTHCHECK relies on the alexa skill server sending a response for "/healthy".
+        We could send anything in response, but "OK" is sufficient.
+
+        As an added bonus, you can check that your Alexa skill server is up with: https://my.alexa.server/healthy
+
+        note: for GET, Flask automatically adds support for HEAD method
+              see: https://flask.palletsprojects.com/en/2.0.x/quickstart/#a-minimal-application ("HTTP Methods")
+        """
+        return "OK"
+
     return skill_blueprint


### PR DESCRIPTION
Add HEALTHCHECK to Docker Compose file for Alexa server skill's container.

When "/healthy" is requested from the skill server, the text "OK" is returned and Docker will report the container is "healthy".  

If the skill server does not respond, then Docker will report the container as "unhealthy".

As an added bonus, you can check that your Alexa skill server is up with (for example): `https://my.alexa.server/healthy`.  I don't think this poses any security risk, because the response method neither reads nor writes to disk or memory.  It just always responds with "OK".
