### PR TITLE
Play Album Intent

### DIFF
--- a/jellyfin_alexa_skill/alexa/handler/__init__.py
+++ b/jellyfin_alexa_skill/alexa/handler/__init__.py
@@ -23,6 +23,7 @@ def get_skill_builder(jellyfin_client: JellyfinClient):
     skill_builder.add_request_handler(SessionEndedRequestHandler())
 
     skill_builder.add_request_handler(PlaySongIntentHandler(jellyfin_client))
+    skill_builder.add_request_handler(PlayAlbumIntentHandler(jellyfin_client))
     skill_builder.add_request_handler(PlayChannelIntentHandler(jellyfin_client))
     skill_builder.add_request_handler(PlayVideoIntentHandler(jellyfin_client))
     skill_builder.add_request_handler(PlayArtistSongsIntentHandler(jellyfin_client))

--- a/jellyfin_alexa_skill/alexa/handler/channel.py
+++ b/jellyfin_alexa_skill/alexa/handler/channel.py
@@ -84,6 +84,7 @@ class PlayChannelIntentHandler(BaseHandler):
                       "Artist": [] }
             top_matches.append( match )
         handler_input.attributes_manager.session_attributes["TopMatches"] = top_matches
+        handler_input.attributes_manager.session_attributes["TopMatchesType"] = MediaType.CHANNEL
 
         # ask user if they want the first one...  (response is handled by YesNoIntentHandler)
         request_text = translation.gettext("Would you like to listen to {name} ?".format(

--- a/jellyfin_alexa_skill/alexa/handler/control.py
+++ b/jellyfin_alexa_skill/alexa/handler/control.py
@@ -142,7 +142,7 @@ class PlayAlbumIntentHandler(BaseHandler):
             artists_ids = set([artists["Id"] for artists in artists_search_results])
 
             album_search_results = [album for album in album_search_results if
-                                   set(artist["Id"] for artist in album["ArtistItems"]).intersection(artists_ids)]
+                                   set(artist["Id"] for artist in album["AlbumArtists"]).intersection(artists_ids)]
 
         if len(album_search_results) == 0:
             # no search results
@@ -161,7 +161,7 @@ class PlayAlbumIntentHandler(BaseHandler):
                 handler_input.response_builder.speak(no_result_response_text)
                 return handler_input.response_builder.response
 
-            artist = item["AlbumArtists"]
+            artist = item["AlbumArtists"][0]
             playback_items = [PlaybackItem(item["Id"], item["Name"], artist)
                               for item in items]
 

--- a/jellyfin_alexa_skill/alexa/handler/control.py
+++ b/jellyfin_alexa_skill/alexa/handler/control.py
@@ -88,6 +88,106 @@ class PlaySongIntentHandler(BaseHandler):
                       "Artist": song_search_results[idx]["Artists"] }
             top_matches.append( match )
         handler_input.attributes_manager.session_attributes["TopMatches"] = top_matches
+        handler_input.attributes_manager.session_attributes["TopMatchesType"] = MediaType.AUDIO
+
+        # ask user if they want the first one...  (response is handled by YesNoIntentHandler)
+        by_artist = ""
+        artists = top_matches[0]["Artist"]
+        if len(artists) > 0:
+            by_artist = translation.gettext("by {artist}".format(artist=artists[0]))
+
+        request_text = translation.gettext("Would you like to hear <break/> {title} {by_artist} ?".format(
+                                                                                     title=top_matches[0]['Name'],
+                                                                                     by_artist=by_artist))
+
+        return handler_input.response_builder.speak(request_text).ask(request_text).response
+
+class PlayAlbumIntentHandler(BaseHandler):
+    def __init__(self, jellyfin_client: JellyfinClient):
+        self.jellyfin_client = jellyfin_client
+
+    def can_handle(self, handler_input: HandlerInput) -> bool:
+        return is_intent_name("PlayAlbumIntent")(handler_input)
+
+    @translate
+    def handle_func(self,
+                    user: User,
+                    handler_input: HandlerInput,
+                    translation: GNUTranslations,
+                    *args,
+                    **kwargs) -> Response:
+        album = handler_input.request_envelope.request.intent.slots["album"].value
+        musician = handler_input.request_envelope.request.intent.slots["musician"].value
+
+        no_result_response_text = translation.gettext(
+            "Sorry, I can't find any songs for this search. Please try again.")
+
+        if not album:
+            handler_input.response_builder.speak(no_result_response_text)
+            return handler_input.response_builder.response
+
+        album = album.lower()
+
+        album_search_results = self.jellyfin_client.search_media_items(user_id=user.jellyfin_user_id,
+                                                                      token=user.jellyfin_token,
+                                                                      term=album,
+                                                                      media=MediaType.ALBUM,
+                                                                      Filters="IsFolder")
+        if musician:
+            musician = musician.lower()
+            # filter album search results with the searched musician
+            artists_search_results = self.jellyfin_client.search_artist(user_id=user.jellyfin_user_id,
+                                                                        token=user.jellyfin_token,
+                                                                        term=musician)
+            artists_ids = set([artists["Id"] for artists in artists_search_results])
+
+            album_search_results = [album for album in album_search_results if
+                                   set(artist["Id"] for artist in album["ArtistItems"]).intersection(artists_ids)]
+
+        if len(album_search_results) == 0:
+            # no search results
+            handler_input.response_builder.speak(no_result_response_text)
+            return handler_input.response_builder.response
+
+        if len(album_search_results) == 1:
+            # there is only one search result, so just play it
+            item = album_search_results[0]
+
+            # get all tracks on the album
+            items = self.jellyfin_client.get_album_items( user_id=user.jellyfin_user_id,
+                                                          token=user.jellyfin_token,
+                                                          album_id=album_search_results[0]["Id"] )
+            if not items:
+                handler_input.response_builder.speak(no_result_response_text)
+                return handler_input.response_builder.response
+
+            artist = item["AlbumArtists"]
+            playback_items = [PlaybackItem(item["Id"], item["Name"], artist)
+                              for item in items]
+
+            user_id = handler_input.request_envelope.context.system.user.user_id
+            playback = set_playback_queue(user_id, playback_items)
+
+            build_stream_response(jellyfin_client=self.jellyfin_client,
+                                  jellyfin_user_id=user.jellyfin_user_id,
+                                  jellyfin_token=user.jellyfin_token,
+                                  handler_input=handler_input,
+                                  playback=playback,
+                                  idx=0)
+
+            return handler_input.response_builder.response
+
+        # more than one search result, so find the best matches and ask user what they want to hear
+        album_match_scores = [get_similarity(item["Name"], album) for item in album_search_results]
+        top_matches_idx = best_matches_by_idx(match_scores=album_match_scores)
+        top_matches = []
+        for idx in top_matches_idx:
+           match = { "Name" : album_search_results[idx]["Name"],
+                      "Id" : album_search_results[idx]["Id"],
+                      "Artist": [album_search_results[idx]["AlbumArtists"][0]["Name"]] }
+           top_matches.append( match )
+        handler_input.attributes_manager.session_attributes["TopMatches"] = top_matches
+        handler_input.attributes_manager.session_attributes["TopMatchesType"] = MediaType.ALBUM
 
         # ask user if they want the first one...  (response is handled by YesNoIntentHandler)
         by_artist = ""
@@ -168,6 +268,7 @@ class PlayVideoIntentHandler(BaseHandler):
                       "Artist": video_search_results[idx]["Artists"] }
             top_matches.append( match )
         handler_input.attributes_manager.session_attributes["TopMatches"] = top_matches
+        handler_input.attributes_manager.session_attributes["TopMatchesType"] = MediaType.VIDEO
 
         # ask user if they want the first one...  (response is handled by YesNoIntentHandler)
         by_artist = ""
@@ -312,9 +413,10 @@ class PauseIntentHandler(BaseHandler):
             playback.offset = handler_input.request_envelope.context.audio_player.offset_in_milliseconds
             playback.save()
 
-        # in case user says stop/cancel during a yes/no dialogue - clear the TopMatches
+        # in case user says stop/cancel during a yes/no dialogue - clear the TopMatches/TopMatchesType
         if "TopMatches" in handler_input.attributes_manager.session_attributes:
             handler_input.attributes_manager.session_attributes["TopMatches"].clear()
+            handler_input.attributes_manager.session_attributes["TopMatchesType"] = ""
 
         handler_input.response_builder.add_directive(StopDirective())
 

--- a/jellyfin_alexa_skill/alexa/handler/control.py
+++ b/jellyfin_alexa_skill/alexa/handler/control.py
@@ -165,7 +165,7 @@ class PlayAlbumIntentHandler(BaseHandler):
                               for item in items]
 
             user_id = handler_input.request_envelope.context.system.user.user_id
-            playback = set_playback_queue(user_id, playback_items)
+            playback = set_playback_queue(user_id, playback_items, reset=True)
 
             build_stream_response(jellyfin_client=self.jellyfin_client,
                                   jellyfin_user_id=user.jellyfin_user_id,

--- a/jellyfin_alexa_skill/alexa/handler/yesno.py
+++ b/jellyfin_alexa_skill/alexa/handler/yesno.py
@@ -67,7 +67,7 @@ class YesNoIntentHandler(BaseHandler):
                 playback_items = [PlaybackItem(item["Id"], item["Name"], item["Artist"])]
 
             user_id = handler_input.request_envelope.context.system.user.user_id
-            playback = set_playback_queue(user_id, playback_items)
+            playback = set_playback_queue(user_id, playback_items, reset=True)
 
             rc = build_stream_response(jellyfin_client=self.jellyfin_client,
                                   jellyfin_user_id=user.jellyfin_user_id,

--- a/jellyfin_alexa_skill/alexa/handler/yesno.py
+++ b/jellyfin_alexa_skill/alexa/handler/yesno.py
@@ -48,14 +48,14 @@ class YesNoIntentHandler(BaseHandler):
             handler_input.attributes_manager.session_attributes["TopMatchesType"] = ""
 
             if (media_type == MediaType.ALBUM.value):
-
+                album = item
                 no_result_response_text = translation.gettext(
                     "Sorry, I can't find any songs with that name. Please try again.")
 
                 # get all tracks on the album
                 items = self.jellyfin_client.get_album_items( user_id=user.jellyfin_user_id,
                                                           token=user.jellyfin_token,
-                                                          album_id=item["Id"] )
+                                                          album_id=album["Id"] )
 
                 if not items:
                     handler_input.response_builder.speak(no_result_response_text)

--- a/jellyfin_alexa_skill/alexa/handler/yesno.py
+++ b/jellyfin_alexa_skill/alexa/handler/yesno.py
@@ -8,7 +8,7 @@ from jellyfin_alexa_skill.alexa.util import translate, build_stream_response, Re
 from jellyfin_alexa_skill.database.db import set_playback_queue
 from jellyfin_alexa_skill.database.model.playback import PlaybackItem
 from jellyfin_alexa_skill.database.model.user import User
-from jellyfin_alexa_skill.jellyfin.api.client import JellyfinClient
+from jellyfin_alexa_skill.jellyfin.api.client import JellyfinClient,MediaType
 
 
 class YesNoIntentHandler(BaseHandler):
@@ -43,10 +43,31 @@ class YesNoIntentHandler(BaseHandler):
 
             # grab the top match, then cleanup the TopMatches list
             item = handler_input.attributes_manager.session_attributes["TopMatches"][0]
+            media_type = handler_input.attributes_manager.session_attributes["TopMatchesType"]
             handler_input.attributes_manager.session_attributes["TopMatches"].clear()
+            handler_input.attributes_manager.session_attributes["TopMatchesType"] = ""
+
+            if (media_type == MediaType.ALBUM.value):
+
+                no_result_response_text = translation.gettext(
+                    "Sorry, I can't find any songs with that name. Please try again.")
+
+                # get all tracks on the album
+                items = self.jellyfin_client.get_album_items( user_id=user.jellyfin_user_id,
+                                                          token=user.jellyfin_token,
+                                                          album_id=item["Id"] )
+
+                if not items:
+                    handler_input.response_builder.speak(no_result_response_text)
+                    return handler_input.response_builder.response
+
+                playback_items = [PlaybackItem(item["Id"], item["Name"], item["Artists"])
+                              for item in items]
+            else:
+                playback_items = [PlaybackItem(item["Id"], item["Name"], item["Artist"])]
 
             user_id = handler_input.request_envelope.context.system.user.user_id
-            playback = set_playback_queue(user_id, [PlaybackItem(item["Id"], item["Name"], item["Artist"])])
+            playback = set_playback_queue(user_id, playback_items)
 
             rc = build_stream_response(jellyfin_client=self.jellyfin_client,
                                   jellyfin_user_id=user.jellyfin_user_id,
@@ -80,6 +101,8 @@ class YesNoIntentHandler(BaseHandler):
 
             return handler_input.response_builder.speak(request_text).ask(request_text).response
         else:
+            handler_input.attributes_manager.session_attributes["TopMatchesType"] = ""
+
             speak_output = translation.gettext("I'm all out of guesses.  Please try asking a different way.")
             handler_input.response_builder.speak(speak_output)
             return handler_input.response_builder.response

--- a/jellyfin_alexa_skill/alexa/setup/interaction/interaction_model_de_DE.json
+++ b/jellyfin_alexa_skill/alexa/setup/interaction/interaction_model_de_DE.json
@@ -99,6 +99,23 @@
           ]
         },
         {
+          "name": "PlayAlbumIntent",
+          "samples": [
+            "Spiele das Album {album}",
+            "Spiele das Album {album} von {musician}"
+          ],
+          "slots": [
+            {
+              "name": "album",
+              "type": "AMAZON.MusicRecording"
+            },
+            {
+              "name": "musician",
+              "type": "AMAZON.Musician"
+            }
+          ]
+        },
+        {
           "name": "PlayVideoIntent",
           "samples": [
             "Spiele das Video {title}"

--- a/jellyfin_alexa_skill/alexa/setup/interaction/interaction_model_en_US.json
+++ b/jellyfin_alexa_skill/alexa/setup/interaction/interaction_model_en_US.json
@@ -97,6 +97,23 @@
           ]
         },
         {
+          "name": "PlayAlbumIntent",
+          "samples": [
+            "Play the album {album}",
+            "Play the album {album} by {musician}"
+          ],
+          "slots": [
+            {
+              "name": "album",
+              "type": "AMAZON.MusicRecording"
+            },
+            {
+              "name": "musician",
+              "type": "AMAZON.Musician"
+            }
+          ]
+        },
+        {
           "name": "PlayVideoIntent",
           "samples": [
             "Play the video {title}"

--- a/jellyfin_alexa_skill/database/db.py
+++ b/jellyfin_alexa_skill/database/db.py
@@ -41,10 +41,15 @@ def get_current_played_item(user_id: str) -> Optional[PlaybackItem]:
         return None
 
 
-def set_playback_queue(user_id: str, queue: List[PlaybackItem]) -> Playback:
+def set_playback_queue(user_id: str, queue: List[PlaybackItem], reset: bool = False) -> Playback:
     playback = get_playback(user_id)
     playback.queue = queue
     playback.current_idx = 0
+
+    if (reset):
+        playback.loop_single = False
+        playback.loop_all = False
+        playback.shuffle = False
 
     if playback.shuffle:
         set_shuffle_queue_idxs(playback)

--- a/jellyfin_alexa_skill/jellyfin/api/client.py
+++ b/jellyfin_alexa_skill/jellyfin/api/client.py
@@ -13,6 +13,7 @@ class MediaType(Enum):
     AUDIO = "Audio"
     VIDEO = "Video,MusicVideo"
     CHANNEL = "TvChannel"
+    ALBUM = "MusicAlbum"
 
 
 class JellyfinClient:
@@ -403,6 +404,29 @@ class JellyfinClient:
 
         res = requests.get(url, headers=headers, params=params)
 
+        if res:
+            json_res = json.loads(res.content)
+            return json_res["Items"]
+        else:
+            res.raise_for_status()
+
+    def get_album_items( self,
+                         user_id: str,
+                         token: str,
+                         album_id: str ):
+        params = {
+            "IncludeItemTypes": "Audio",
+            "Recursive": True,
+            "sortBy": "SortName",
+            "ParentId": album_id
+        }
+        url = self.server_endpoint + f"/Users/{user_id}/Items"
+        headers = {
+            "Content-Type": "application/json",
+            "X-Emby-Authorization": self._build_emby_auth_header(token=token)
+        }
+
+        res = requests.get(url, headers=headers, params=params)
         if res:
             json_res = json.loads(res.content)
             return json_res["Items"]


### PR DESCRIPTION
Add ability to play an album (a Jellyfin "MusicAlbum").

Enabled with "Ask Jellyfin Player to play album <album_name>" and "Ask jellyfin player to play album <name> by <musician>".

Also added ability to reset Playback flags (loop_single, loop_all and shuffle) when setting a new playback queue.  This fixes the bug that played the first track twice before moving on to other tracks in the queue, if flags had been previously set.